### PR TITLE
fix: Navigation issues in Navbar component

### DIFF
--- a/sigmaya-frontend/app/dashboard/student/page.tsx
+++ b/sigmaya-frontend/app/dashboard/student/page.tsx
@@ -62,6 +62,16 @@ export default function StudentDashboard() {
   const [currentView, setCurrentView] = useState('')
 
   useEffect(() => {
+    // Limpiar el hash si venimos de otra ruta
+    const cleanHash = () => {
+      if (window.location.hash) {
+        window.location.hash = '';
+      }
+    }
+
+    // Limpiar el hash al montar el componente
+    cleanHash();
+
     // Obtener el hash inicial
     const hash = window.location.hash.replace('#', '')
     setCurrentView(hash)
@@ -111,7 +121,7 @@ export default function StudentDashboard() {
 
   return (
     <div className="min-h-screen bg-gray-100">
-      <Navbar userName={userName} userRoles={userRoles}  />
+      <Navbar userName={userName} userRoles={userRoles} onRoleChange={() => window.location.hash = ''} />
       <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
         <div className="px-4 py-6 sm:px-0">
           {renderContent()}

--- a/sigmaya-frontend/components/navbar.tsx
+++ b/sigmaya-frontend/components/navbar.tsx
@@ -44,9 +44,9 @@ export default function Navbar({ userRoles, userName }: NavbarProps) {
                   userRoles.includes(tab.role) && (
                     <Link
                       key={tab.role}
-                      href={`${currentPath}/${tab.role.toLowerCase()}`}
+                      href={`/dashboard/${tab.role.toLowerCase()}`}
                       className={`${
-                        currentPath.includes(tab.label.toLowerCase())
+                        currentPath === `/dashboard/${tab.role.toLowerCase()}`
                           ? "border-indigo-500 text-gray-900"
                           : "border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700"
                       } inline-flex items-center px-1 pt-1 border-b-2 text-sm font-medium`}

--- a/sigmaya-frontend/components/navbar.tsx
+++ b/sigmaya-frontend/components/navbar.tsx
@@ -8,9 +8,10 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 interface NavbarProps {
   userRoles: Array<"student" | "teacher" | "friend">;
   userName: string;
+  onRoleChange?: () => void;
 }
 
-export default function Navbar({ userRoles, userName }: NavbarProps) {
+export default function Navbar({ userRoles, userName, onRoleChange }: NavbarProps) {
   const currentPath = usePathname();
 
   const tabs: Array<{ role: "student" | "teacher" | "friend"; label: string }> = [
@@ -18,6 +19,12 @@ export default function Navbar({ userRoles, userName }: NavbarProps) {
     { role: "teacher", label: "Profesor" },
     { role: "friend", label: "Exalumno" },
   ];
+
+  const handleRoleChange = () => {
+    if (onRoleChange) {
+      onRoleChange();
+    }
+  };
 
   return (
     <nav className="bg-white shadow-md">
@@ -31,6 +38,7 @@ export default function Navbar({ userRoles, userName }: NavbarProps) {
             <div className="hidden sm:ml-6 sm:flex sm:space-x-8">
               <Link
                 href="/dashboard"
+                onClick={handleRoleChange}
                 className={`${
                   currentPath === "/dashboard"
                     ? "border-indigo-500 text-gray-900"
@@ -45,6 +53,7 @@ export default function Navbar({ userRoles, userName }: NavbarProps) {
                     <Link
                       key={tab.role}
                       href={`/dashboard/${tab.role.toLowerCase()}`}
+                      onClick={handleRoleChange}
                       className={`${
                         currentPath === `/dashboard/${tab.role.toLowerCase()}`
                           ? "border-indigo-500 text-gray-900"


### PR DESCRIPTION
This PR addresses two critical navigation issues:

1. **Route Accumulation**: Routes were incorrectly accumulating when navigating between roles
   - Before: `/dashboard/student/teacher`
   - After: `/dashboard/teacher`

2. **Hash State Persistence**: Hash state (#registro-cursos) was persisting when switching between roles
   - Before: Hash persisted causing incorrect view to be displayed
   - After: Hash automatically clears when changing roles

## Implemented Changes
- Refactored route construction in Navbar to use absolute paths
- Implemented hash cleanup system when switching between roles
- Added `onRoleChange` prop to handle role transitions
- Updated navigation logic in Navbar links

## Suggested Testing
- [ ] Navigate between roles (student/teacher) and verify routes
- [ ] Verify that switching roles from a hashed view shows the main dashboard
- [ ] Check that navigation links work correctly in all views